### PR TITLE
Add missing include

### DIFF
--- a/include/delaunator.cpp
+++ b/include/delaunator.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <numeric>
 #include <limits>


### PR DESCRIPTION
`assert` macro is used in `delaunator.cpp`:
https://github.com/abellgithub/delaunator-cpp/blob/8e95f0c89b2d0cf37428ca4cb12dfd4acba97be5/include/delaunator.cpp#L378-L379

But there is no inclusion of `<cassert>` or `assert.h`.
This will cause build errors in VS2022:
error C3861: 'assert': identifier not found.